### PR TITLE
fixed a bug that cleared out stats if only one item was updated

### DIFF
--- a/client/src/pages/userStats.js
+++ b/client/src/pages/userStats.js
@@ -76,13 +76,17 @@ class UserStats extends Component {
 	};
 
 	handleInputChange = event => {
-		const { name, value } = event.target;
-		if (parseInt(value) > 0) {
-			this.setState({
-				[name]: value,
-			});
-		}
-	};
+    let { name, value } = event.target;
+	
+	/* Validate Input Stats: only numbers allowed */
+	value = value.replace(/[^\d]/, "");
+
+	if (parseInt(value) !== 0) {
+		this.setState({
+		[name]: value,
+		});
+  	}
+  };
 
 	handleCancel = event => {
 		event.preventDefault();

--- a/client/src/pages/userStats.js
+++ b/client/src/pages/userStats.js
@@ -99,7 +99,7 @@ class UserStats extends Component {
 	handleFormSubmit = event => {
 		event.preventDefault();
 		let dataArray = [
-		{height: this.state.height},
+		{weight: this.state.weight},
 		{backSquat: this.state.backSquat},
 		{cleanJerk: this.state.cleanJerk},
 		{snatch: this.state.snatch},
@@ -112,8 +112,8 @@ class UserStats extends Component {
 		{fiveK: this.state.fiveKMinutes ? parseInt(this.state.fiveKMinutes * 60) + parseInt(this.state.fiveKSeconds) : ""},
 		{fourHundredMeter: this.state.fourHundredMeterMinutes ? parseInt(this.state.fourHundredMeterMinutes * 60) + parseInt(this.state.fourHundredMeterSeconds) : ""},
 		];
-		let filteredDataArray  = dataArray.filter(value => Object.values(value) !== "");
-		// console.log(filteredDataArray);
+		let filteredDataArray  = dataArray.filter(item => item[Object.keys(item)[0]] !== "");
+
 			if (filteredDataArray) {
 				API.updateStats({
 					userId: this.props.userData._id,


### PR DESCRIPTION
While testing for the weight being null, I noticed that we had a bug that cleared all the stats if only one item was being updated. 

The code was updated to not push non updated stats to the backend, fixing the bug. 